### PR TITLE
raised welcome text

### DIFF
--- a/src/app/welcome/welcome.component.scss
+++ b/src/app/welcome/welcome.component.scss
@@ -30,7 +30,7 @@
   flex-direction: column;
   justify-content: space-evenly;
   align-items: center;
-  margin-top: 50px;
+  margin-top: -250px;
   @media (min-width: 600px) {
     .play-container {
       margin-top: 200px;


### PR DESCRIPTION
Raised the content on the front page to make it go over the center, so that there is no edge of light-bleed when it is shown in a 2x2 grid of screens.


![image](https://user-images.githubusercontent.com/7712490/169973534-5f4dd5d0-22f7-4050-9b9f-4abd7e52c850.png)
