### PR TITLE
Added sizes and content customization to SpeechBubbleComponent

### DIFF
--- a/src/app/game/speech-bubble/speech-bubble.component.html
+++ b/src/app/game/speech-bubble/speech-bubble.component.html
@@ -5,4 +5,5 @@
   <ng-content select="[slot='body']">
     <p class="body">{{ bodyText }}</p>
   </ng-content>
+  <ng-content select="[slot='body-alt']"></ng-content>
 </div>

--- a/src/app/game/speech-bubble/speech-bubble.component.scss
+++ b/src/app/game/speech-bubble/speech-bubble.component.scss
@@ -1,18 +1,37 @@
 @import '../../../variables.scss';
 
 * {
-  color: --bbTextColor;
   text-align: center;
   text-shadow: none;
 }
 
-.title {
-  font-family: 'Aeonik-Bold';
-  font-size: 48px;
+.title,
+.body {
+  font-size: var(--bbFontSize);
+  line-height: var(--bbLineHeight);
 }
 
-.body {
-  font-size: 48px;
+.title {
+  font-family: AeonikBold;
+}
+
+.large {
+  --bbFontSize: 48px;
+  --bbLineHeight: 48px;
+  --bbPadding: 2rem;
+  --bbMaxWidth: 60vw;
+}
+.medium {
+  --bbFontSize: 36px;
+  --bbLineHeight: 36px;
+  --bbPadding: 1rem;
+  --bbMaxWidth: 50vw;
+}
+.small {
+  --bbFontSize: 28px;
+  --bbLineHeight: 28px;
+  --bbPadding: 1rem;
+  --bbMaxWidth: 50vw;
 }
 
 .speech-bubble,
@@ -25,14 +44,16 @@
   --bbTextColor: black;
   --bbArrowSize: 2rem;
   --bbBorderRadius: 1rem;
-  --bbPadding: 2rem;
+  --bbPaddingX: 2rem;
 
   background: var(--bbColor);
   color: var(--bbTextColor);
   border-radius: var(--bbBorderRadius);
   padding: var(--bbPadding);
+  padding-left: var(--bbPaddingX);
+  padding-right: var(--bbPaddingX);
+  max-width: var(--bbMaxWidth);
   position: relative;
-  line-height: 48px;
 }
 
 .speech-bubble::before {

--- a/src/app/game/speech-bubble/speech-bubble.component.ts
+++ b/src/app/game/speech-bubble/speech-bubble.component.ts
@@ -12,8 +12,9 @@ export class SpeechBubbleComponent {
   @Input() textColor: CustomColorsIO = CustomColorsIO.black; // Default color
   @Input() bubbleColor: CustomColorsIO = CustomColorsIO.pastelBlue; // Default color
   @Input() titleText: string | undefined = '';
-  @Input() bodyText = 'Hello world!';
+  @Input() bodyText: string | undefined = 'Hello world!';
 
+  // Arrow location and direction
   private _pointerSide: PointerSide = PointerSide.Top;
 
   @Input() set pointerSide(value: PointerSide) {
@@ -44,9 +45,25 @@ export class SpeechBubbleComponent {
     return this._isFlipped;
   }
 
+  // Bubble format
+  private _bubbleSize: 'small' | 'medium' | 'large' = 'large';
+
+  @Input()
+  set bubbleSize(value: 'small' | 'medium' | 'large') {
+    this._bubbleSize = this.formatString(value) as 'small' | 'medium' | 'large';
+  }
+
+  get bubbleSize(): 'small' | 'medium' | 'large' {
+    return this._bubbleSize;
+  }
+
+  formatString(value: string): string {
+    return value?.trim().toLowerCase();
+  }
+
   computedClasses(): string[] {
     this.validateConfiguration();
-    return ['speech-bubble', this._pointerSide, this._arrowAlignment, this._isFlipped ? 'flip' : ''];
+    return ['speech-bubble', this._pointerSide, this._arrowAlignment, this._isFlipped ? 'flip' : '', this._bubbleSize];
   }
 
   validateConfiguration() {

--- a/src/app/welcome/welcome.component.ts
+++ b/src/app/welcome/welcome.component.ts
@@ -9,14 +9,13 @@ import { TranslatePipe } from '../core/translation.pipe';
 import { Observable, Subject, takeUntil } from 'rxjs';
 import { CommonModule } from '@angular/common';
 import { SupportedLanguages } from '../shared/models/interfaces';
-import { SpeechBubbleComponent } from '../game/speech-bubble/speech-bubble.component';
 
 @Component({
   selector: 'app-welcome',
   templateUrl: './welcome.component.html',
   styleUrls: ['./welcome.component.scss'],
   standalone: true,
-  imports: [RouterLink, RouterLinkActive, MatButton, MatIcon, TranslatePipe, CommonModule, SpeechBubbleComponent],
+  imports: [RouterLink, RouterLinkActive, MatButton, MatIcon, TranslatePipe, CommonModule],
 })
 export class WelcomeComponent implements OnInit, OnDestroy {
   private headerClicks = 0;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -22,6 +22,11 @@
   src: url('./assets/fonts/Aeonik/Aeonik-Black.otf') format('opentype');
 }
 
+@font-face {
+  font-family: AeonikBold;
+  src: url('./assets/fonts/Aeonik/Aeonik-Bold.otf') format('opentype');
+}
+
 body {
   font-family: 'Barlow Condensed', sans-serif;
   -webkit-touch-callout: none; /* iOS Safari */


### PR DESCRIPTION
Speech bubble components now have another parameter, for setting size small, medium or large:
```
<app-speech-bubble
    [pointerSide]="PointerSide.Left"
    [arrowAlignment]="ArrowAlignment.Bottom"
    [isFlipped]="false"
    [titleText]="'WELCOME_MESSAGE' | translate "
    [bodyText]="'HELP_ME_LEARN' | translate "
    [textColor]="CustomColorsIO.black"
    [bubbleColor]="CustomColorsIO.pastelBlue"
    [bubbleSize]="'small'" 
  />
```


If there is a need to add text with special formatting to the speech bubble, it can now be done like this (e.g.). The p-tag can be replaced by any html tag: 
```
<app-speech-bubble
    [pointerSide]="PointerSide.Left"
    [arrowAlignment]="ArrowAlignment.Bottom"
    [isFlipped]="false"
    [titleText]="'WELCOME_MESSAGE' | translate "
    [textColor]="CustomColorsIO.white"
    [bubbleColor]="CustomColorsIO.teal"
    [bubbleSize]="'small'"
  >
    <p someLocalClass slot="body-alt">{{'HELP_ME_LEARN' | translate}}</p>
  </app-speech-bubble>
```