### PR TITLE
Fixed animation speed on difficulty screen + ability to skip animation

### DIFF
--- a/src/app/game/game-pick-difficulty/game-pick-difficulty.component.html
+++ b/src/app/game/game-pick-difficulty/game-pick-difficulty.component.html
@@ -1,5 +1,5 @@
 <div class="container-background">
-  <div class="container">
+  <div class="container" (click)="skipAnimation()" (keypress)="skipAnimation()" tabindex="0">
     <header class="header">
       <button class="logo">
         <img src="assets/logo/IO-logo-inverted_transparent-bg.png" alt="logo" aria-label="Gå til admin side" />
@@ -34,17 +34,35 @@
             >
             </app-speech-bubble>
             <div class="button-container" [@show]="stateButtons">
-              <button mat-raised-button class="button" id="easy-button" (click)="startDrawing('easy')">
+              <button
+                mat-raised-button
+                [disabled]="buttonsAreDisabled"
+                class="button"
+                id="easy-button"
+                (click)="startDrawing('easy')"
+              >
                 <div class="button-text">
                   {{ 'EASY_BUTTON' | translate }}
                 </div>
               </button>
-              <button mat-raised-button class="button" id="medium-button" (click)="startDrawing('medium')">
+              <button
+                mat-raised-button
+                [disabled]="buttonsAreDisabled"
+                class="button"
+                id="medium-button"
+                (click)="startDrawing('medium')"
+              >
                 <div class="button-text">
                   {{ 'MEDIUM_BUTTON' | translate }}
                 </div>
               </button>
-              <button mat-raised-button class="button" id="hard-button" (click)="startDrawing('hard')">
+              <button
+                mat-raised-button
+                [disabled]="buttonsAreDisabled"
+                class="button"
+                id="hard-button"
+                (click)="startDrawing('hard')"
+              >
                 <div class="button-text">
                   {{ 'HARD_BUTTON' | translate }}
                 </div>

--- a/src/app/game/game-pick-difficulty/game-pick-difficulty.component.ts
+++ b/src/app/game/game-pick-difficulty/game-pick-difficulty.component.ts
@@ -24,12 +24,13 @@ import { trigger, state, style, animate, transition } from '@angular/animations'
     trigger('show', [
       state('hidden', style({ opacity: 0 })),
       state('visible', style({ opacity: 1 })),
-      transition('hidden => visible', [animate('800ms')]),
+      transition('hidden => visible', [animate('0.3s')]),
     ]),
   ],
 })
 export class GamePickDifficultyComponent implements OnInit {
   config = this.gameConfigService.getConfig;
+  private animationTimeouts: NodeJS.Timeout[] = [];
 
   PointerSide = PointerSide;
   ArrowAlignment = ArrowAlignment;
@@ -40,6 +41,7 @@ export class GamePickDifficultyComponent implements OnInit {
   stateFirstBubbleI = 'hidden';
   stateFirstBubbleO = 'hidden';
   stateButtons = 'hidden';
+  buttonsAreDisabled = true;
 
   constructor(
     private gameConfigService: GameConfigService,
@@ -60,15 +62,52 @@ export class GamePickDifficultyComponent implements OnInit {
   }
 
   startAnimation() {
-    setTimeout(() => {
-      this.stateFirstBubbleO = 'visible';
-      this.stateFigureO = 'visible';
-    }, 500);
-    setTimeout(() => {
-      this.stateFirstBubbleI = 'visible';
-      this.stateFigureI = 'visible';
-      this.stateButtons = 'visible';
-    }, 2000);
+    const steps = [
+      {
+        delay: 500,
+        action: () => {
+          this.stateFigureO = 'visible';
+        },
+      },
+      {
+        delay: 350,
+        action: () => {
+          this.stateFirstBubbleO = 'visible';
+        },
+      },
+      {
+        delay: 750,
+        action: () => {
+          this.stateFigureI = 'visible';
+        },
+      },
+      {
+        delay: 350,
+        action: () => {
+          this.stateButtons = 'visible';
+          this.buttonsAreDisabled = false;
+          this.stateFirstBubbleI = 'visible';
+        },
+      },
+    ];
+    let totalDelay = 0;
+    steps.forEach((step) => {
+      totalDelay += step.delay;
+      const timeout = setTimeout(step.action, totalDelay);
+      this.animationTimeouts.push(timeout);
+    });
+  }
+
+  skipAnimation() {
+    this.animationTimeouts.forEach((timeout) => clearTimeout(timeout));
+    this.animationTimeouts = [];
+
+    this.stateFirstBubbleO = 'visible';
+    this.stateFirstBubbleI = 'visible';
+    this.stateFigureI = 'visible';
+    this.stateFigureO = 'visible';
+    this.stateButtons = 'visible';
+    this.buttonsAreDisabled = false;
   }
 
   startDrawing(difficulty: 'easy' | 'medium' | 'hard') {

--- a/src/app/welcome/welcome.component.scss
+++ b/src/app/welcome/welcome.component.scss
@@ -65,7 +65,6 @@ header {
   font-family: AeonikMedium;
   font-size: 24px;
   font-style: normal;
-  font-weight: 700;
   line-height: normal;
 }
 


### PR DESCRIPTION
The changes made to difficulty screen:
- Animation of the I and O figure, and the speech bubbles are now faster, and match better with the animation speed of the welcome screen
- The difficulty buttons are disabled before they show up so clicking on invisible buttons is not a problem
- Clicking anywhere on the screen will result in skipping the animation and all the elements showing up at once