### PR TITLE
Now wont show same label twice on loss intermediary screen

### DIFF
--- a/src/app/game/game-draw/game-draw.component.ts
+++ b/src/app/game/game-draw/game-draw.component.ts
@@ -145,6 +145,7 @@ export class GameDrawComponent implements OnInit, OnDestroy {
       this.prediction = prediction;
       const sortedCertaintyArr = this.sortOnCertainty(prediction);
       this.updateAiGuess(sortedCertaintyArr);
+      this.drawingService.sortedCertainty = sortedCertaintyArr;
       if (this.prediction && this.prediction.hasWon && !this.hasAddedResult) {
         this.soundService.playResultSound(this.prediction.hasWon);
         this.updateResult(true);
@@ -348,7 +349,7 @@ export class GameDrawComponent implements OnInit, OnDestroy {
       this.updateAiGuess(sortedCertaintyArr);
       if (this.drawingService.roundIsDone(res.hasWon, res.gameState)) {
         this.gameStateService.goToPage(GAMESTATE.intermediateResult);
-
+        this.drawingService.sortedCertainty = sortedCertaintyArr;
         this.soundService.playResultSound(res.hasWon);
         const score = this.score > 0 ? this.score : 0;
         this.drawingService.lastResult.score = Math.round(score);

--- a/src/app/game/game-intermediate-result/game-example-drawings/wrong-guess/wrong-guess.component.ts
+++ b/src/app/game/game-intermediate-result/game-example-drawings/wrong-guess/wrong-guess.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { SpeechBubbleComponent } from '@/app/game/speech-bubble/speech-bubble.component';
 import { OAvatarComponent } from '@/assets/avatars/o-avatar/o-avatar.component';
-import { ArrowAlignment, PointerSide } from '@/app/shared/models/interfaces';
+import { ArrowAlignment, Certainty, PointerSide } from '@/app/shared/models/interfaces';
 import { CustomColorsIO } from '@/app/shared/customColors';
 import { TranslatePipe } from '@/app/core/translation.pipe';
 import { ExampleDrawingService } from '@/app/game/services/example-drawing.service';
@@ -39,7 +39,7 @@ export class WrongGuessComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.label = this.drawingService.lastResult.word;
-    this.guess = this.drawingService.lastResult.guess;
+    this.updateAiGuess(this.drawingService.sortedCertainty);
 
     if (this.gameStateService.isSingleplayer()) {
       this.exampleDrawings = this.exampleDrawingService.getExampleDrawings(2);
@@ -79,5 +79,11 @@ export class WrongGuessComponent implements OnInit, OnDestroy {
           this.guessedDrawings = res;
         })
     );
+  }
+  updateAiGuess(sortedCertaintyArr: Certainty[]) {
+    if (sortedCertaintyArr && sortedCertaintyArr.length > 1) {
+      const bestGuess = sortedCertaintyArr[0].label;
+      this.guess = bestGuess === this.label ? sortedCertaintyArr[1].label : bestGuess;
+    }
   }
 }

--- a/src/app/game/services/drawing.service.ts
+++ b/src/app/game/services/drawing.service.ts
@@ -9,7 +9,7 @@ import {
   PredictionData,
   Score,
 } from '@/app/shared/models/backend-interfaces';
-import { Result } from '@/app/shared/models/interfaces';
+import { Certainty, Result } from '@/app/shared/models/interfaces';
 import { ResultsMock } from '@/app/shared/mocks/results.mock';
 import { endpoints } from '@/app/shared/models/endpoints';
 import { TranslationService } from '@/app/core/translation.service';
@@ -30,6 +30,7 @@ export class DrawingService {
   classificationDone = false;
   guess = '';
   secondsUsedOnLastRound = 0;
+  sortedCertainty: Certainty[] = [];
 
   private readonly _guessUsed = new BehaviorSubject<number>(1);
   private readonly _gameOver = new BehaviorSubject<boolean>(false);


### PR DESCRIPTION
Bug was: If the game thought your word looked most like spoon (e.g. 26% certain), it would say - i thought you drew "spoon", the actual word was "spoon".

Now changed to show the second most likely word if the round label and the highest  certainty word guessed is the same one