### PR TITLE
images no longer being stretched in results

### DIFF
--- a/src/app/game/game-result/game-result.component.scss
+++ b/src/app/game/game-result/game-result.component.scss
@@ -127,6 +127,8 @@ app-speech-bubble p {
 .game-result-img {
   width: 19rem;
   height: 14rem;
+  object-fit: contain;
+  background-color: white;
 }
 
 .card-won {


### PR DESCRIPTION
Images were stretched before due to rectangular boxes in end of game screen. I like their shape so i changed the object fit and gave the empty space a white background