### PR TITLE
Remove swiping functionality between pages

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -39,11 +39,12 @@
 
 html,
 body {
-  touch-action: pan-x pan-y;
-  -ms-touch-action: pan-x pan-y;
+  touch-action: none;
+  -ms-touch-action: none;
   overflow: hidden;
   width: 100%;
   height: 100%;
+  overscroll-behavior: none; /* Disables all overscroll behavior */
 }
 
 body {


### PR DESCRIPTION
I styles.scss la til overscroll-behavior til none, slik at man ikke skal kunne swipe til neste eller forrige side man har besøkt, som ødelegger flyten til spillet. 