### PR TITLE
Legg til synlig countdown timer i manuell prompt

### DIFF
--- a/src/app/game/game-intermediate-result/game-intermediate-result-header/confirm-exit-dialog/confirm-exit-dialog.component.html
+++ b/src/app/game/game-intermediate-result/game-intermediate-result-header/confirm-exit-dialog/confirm-exit-dialog.component.html
@@ -1,6 +1,6 @@
 <mat-dialog-content id="exitGameText">
   <p>
-    {{ 'CONFIRM_EXIT_MESSAGE' | translate }}
+    {{ 'CONFIRM_EXIT_MESSAGE' | translate }} <strong>{{ timer }}</strong> {{ 'SECONDS' | translate }}
   </p>
 </mat-dialog-content>
 <mat-dialog-actions id="exitGameActions">


### PR DESCRIPTION
Gjør timer synlig, med TIMER variabel i confirm-exit-dialog komponent, slik at man ser hvor lang tid før man automatisk sendt tilbake til startpage. 