### PR TITLE
Gateway error when backend fails

### DIFF
--- a/src/app/game/game-word-to-draw/game-word-to-draw.component.ts
+++ b/src/app/game/game-word-to-draw/game-word-to-draw.component.ts
@@ -7,6 +7,7 @@ import { MatIcon } from '@angular/material/icon';
 import { MatButton } from '@angular/material/button';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { UpperCasePipe } from '@angular/common';
 import { GameConfigService } from '../services/game-config.service';
 import { TranslationService } from '@/app/core/translation.service';
@@ -22,6 +23,7 @@ import { PointerSide, ArrowAlignment } from '@/app/shared/models/interfaces';
 import { CustomButtonComponent } from '../custom-button/custom-button.component';
 import { ButtonStyleClass } from '@/app/shared/buttonStyles';
 import { ConfirmExitDialogComponent } from '../game-intermediate-result/game-intermediate-result-header/confirm-exit-dialog/confirm-exit-dialog.component';
+import { routes } from '../../shared/models/routes';
 
 @Component({
   selector: 'app-game-word-to-draw',
@@ -75,7 +77,8 @@ export class GameWordToDrawComponent implements OnInit, OnDestroy {
     private multiplayerService: MultiplayerService,
     private translationService: TranslationService,
     private exampleDrawingService: ExampleDrawingService,
-    private router: Router
+    private router: Router,
+    private snackBar: MatSnackBar
   ) {}
 
   ngOnInit(): void {
@@ -88,30 +91,43 @@ export class GameWordToDrawComponent implements OnInit, OnDestroy {
     if (this.isSinglePlayer) {
       if (this.drawingService.gameHasStarted) {
         this.subscriptions.add(
-          this.drawingService.getLabel().subscribe((res) => {
-            this.label = res.label;
-            this.loading = false;
+          this.drawingService.getLabel().subscribe({
+            next: (res) => {
+              this.label = res.label;
+              this.loading = false;
+            },
+            error: (error) => {
+              console.error("An error occurred while fetching the label:", error.message);
+              this.loading = false;
+            },
           })
         );
-        this.subscriptions.add(
-          this.drawingService.guessUsed$.subscribe((res) => {
-            this.guessUsed = res;
-          })
-        );
-      } else {
-        this.subscriptions.add(
-          this.drawingService.startGame().subscribe(() => {
-            this.loading = false;
-            this.label = this.drawingService.label;
-            this.drawingService.gameHasStarted = true;
-          })
-        );
+
         this.subscriptions.add(
           this.drawingService.guessUsed$.subscribe((res) => {
             this.guessUsed = res;
           })
         );
       }
+       else {
+        this.subscriptions.add(
+        this.drawingService.startGame().subscribe({
+          next: () => {
+            this.loading = false;
+            this.label = this.drawingService.label;
+            this.drawingService.gameHasStarted = true;
+          },
+          error: (error) => {
+            console.error("An error occurred while starting the game:", error);
+            this.snackBar.open('A gateway error occurred. Please try again later.', 'Close', {
+              duration: 5000,
+            });
+            this.loading = false;
+            this.goHome();
+          },
+        })
+);
+
     }
     if (this.isMultiPlayer) {
       const player = this.multiplayerService.stateInfo.player_nr;
@@ -132,6 +148,7 @@ export class GameWordToDrawComponent implements OnInit, OnDestroy {
       );
     }
   }
+}
 
   toDrawingBoard() {
     if (this.gameStateService.isSingleplayer()) {
@@ -163,6 +180,10 @@ export class GameWordToDrawComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.subscriptions.unsubscribe();
+  }
+
+  goHome() {
+    this.router.navigate([routes.LANDING]);
   }
 
   buttonStyle(): string {

--- a/src/app/game/services/drawing.service.ts
+++ b/src/app/game/services/drawing.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { Observable, BehaviorSubject } from 'rxjs';
-import { tap, switchMap } from 'rxjs/operators';
+import { HttpClient, HttpHeaders, HttpErrorResponse } from '@angular/common/http';
+import { Observable, BehaviorSubject, throwError  } from 'rxjs';
+import { tap, switchMap, catchError } from 'rxjs/operators';
 import {
   StartGamePlayerId,
   GameLabel,
@@ -132,6 +132,9 @@ export class DrawingService {
         switchMap((res) => {
           this.playerid = res.player_id;
           return this.getLabel();
+        }),
+        catchError((error) => {
+          return throwError(() => error);
         })
       );
   }
@@ -140,9 +143,13 @@ export class DrawingService {
     const currentLang = this.translationService.getCurrentLang();
     return this.http
       .post<GameLabel>(`${this.baseUrl}/${endpoints.GETLABEL}?player_id=${this.playerid}&lang=${currentLang}`, {})
-      .pipe(tap((res) => (this.label = res.label)));
+      .pipe(tap((res) => (this.label = res.label)),
+      catchError((error) => {
+      return throwError(() => error);
+      })
+    );
   }
-
+  
   getHighscore(): Observable<HighscoreData> {
     const difficultyId = this.config.difficultyId;
     const headers = new HttpHeaders();

--- a/src/app/game/services/drawing.service.ts
+++ b/src/app/game/services/drawing.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders, HttpErrorResponse } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable, BehaviorSubject, throwError  } from 'rxjs';
 import { tap, switchMap, catchError } from 'rxjs/operators';
 import {


### PR DESCRIPTION
Functionality to catch error HTTP response so that an alert is shown and the user is taken back to the homepage if a word to draw is not fetched from backend