### PR TITLE
Sp24 725 inactively timer bug

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -54,7 +54,7 @@ export class AppComponent implements OnInit {
 
       if (this.router.url === '/welcome') {
         this.router.navigate(['/']);
-      } else if (this.router.url !== '/' && this.router.url !== '/admin') {
+      } else if (this.router.url !== '/' && !this.router.url.startsWith('/admin')) {
         this.openDialog();
       }
     });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,7 +3,6 @@ import { Subject } from 'rxjs';
 import { Router } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 import { RouterOutlet } from '@angular/router';
-
 import { IdleTimeoutComponent } from './game/idle-timeout/idle-timeout.component';
 import { routeTransitionAnimations } from './route-transition-animations';
 import { environment } from '../environments/environment';
@@ -20,21 +19,19 @@ import { GAMESTATE } from './shared/models/interfaces';
 })
 export class AppComponent implements OnInit {
   title = 'Teknisk Museum';
-
   userActivity = 0;
   userInactive = new Subject<boolean | undefined>();
-
   isDialogOpen = false;
   inactivityTime = environment.inactivityTime;
-  hasResetForIntermediateResult = false; //Idle timer should reset only once when entering intermediateResult page.
+  hasResetInIntermediateResultPage = false; //Reset idle-timer only once on intermediate resultpage. 
 
   constructor(private gameStateService: GameStateService, private router: Router, public dialog: MatDialog) {}
 
   ngOnInit(): void {
     this.setDialogTimeout();
     this.gameStateService.currentPage$.subscribe(currentPage => {
-      if (currentPage !== GAMESTATE.intermediateResult && this.hasResetForIntermediateResult) {
-        this.hasResetForIntermediateResult = false;
+      if (currentPage !== GAMESTATE.intermediateResult && this.hasResetInIntermediateResultPage) {
+        this.hasResetInIntermediateResultPage = false;
       }
 
     })
@@ -45,10 +42,10 @@ export class AppComponent implements OnInit {
         return;
       }
       
-      if (this.gameStateService.getCurrentPage() === GAMESTATE.intermediateResult && !this.hasResetForIntermediateResult) {
+      if (this.gameStateService.getCurrentPage() === GAMESTATE.intermediateResult && !this.hasResetInIntermediateResultPage) {
         clearTimeout(this.userActivity);
         this.setDialogTimeout();
-        this.hasResetForIntermediateResult = true;
+        this.hasResetInIntermediateResultPage = true;
         return;
       }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -26,15 +26,29 @@ export class AppComponent implements OnInit {
 
   isDialogOpen = false;
   inactivityTime = environment.inactivityTime;
+  hasResetForIntermediateResult = false; //Idle timer should reset only once when entering intermediateResult page.
 
   constructor(private gameStateService: GameStateService, private router: Router, public dialog: MatDialog) {}
 
   ngOnInit(): void {
     this.setDialogTimeout();
-    this.userInactive.subscribe(() => {
+    this.gameStateService.currentPage$.subscribe(currentPage => {
+      if (currentPage !== GAMESTATE.intermediateResult && this.hasResetForIntermediateResult) {
+        this.hasResetForIntermediateResult = false;
+      }
+
+    })
+    this.userInactive.subscribe(() => { 
       if (this.gameStateService.getCurrentPage() === GAMESTATE.drawingBoard) {
         clearTimeout(this.userActivity);
         this.setDialogTimeout();
+        return;
+      }
+      
+      if (this.gameStateService.getCurrentPage() === GAMESTATE.intermediateResult && !this.hasResetForIntermediateResult) {
+        clearTimeout(this.userActivity);
+        this.setDialogTimeout();
+        this.hasResetForIntermediateResult = true;
         return;
       }
 


### PR DESCRIPTION
- Fikset at inactivity timer resetter når man dukker opp på intermediate result page, da den kan bli automatisk sendt til fra drawing board etter timer går til 0. Reset for at idle prompt ikke dukker opp for tidlig. 

- Fjern at idle prompt dukker opp i det hele tatt på admin page. 