### PR TITLE
avoids opening idle timeout box while drawing

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -37,14 +37,11 @@ export class AppComponent implements OnInit {
 
     //Whenever user become inactive (25sec) -> open prompt. 
     this.userInactive.subscribe(() => { 
-      //Never open prompt on drawing page. 
-      if (this.gameStateService.getCurrentPage() === GAMESTATE.drawingBoard) {
-        this.setDialogTimeout();
-      }
-
       if (this.router.url === '/welcome') {
         this.router.navigate(['/']);
-      } else if (this.router.url !== '/' && !this.router.url.startsWith('/admin')) {
+
+        //avoids opening idle timeout box on initial page, admin page and while drawing
+      } else if (this.router.url !== '/' && !this.router.url.startsWith('/admin') && this.gameStateService.getCurrentPage() !== GAMESTATE.drawingBoard) {
         this.openDialog();
       }
     });

--- a/src/app/game/services/web-socket.service.ts
+++ b/src/app/game/services/web-socket.service.ts
@@ -55,6 +55,8 @@ export class WebSocketService {
       this.handleConnectionError();
     });
 
+    // Disable any type check for only this one because the spread parameter will take parameters of different types
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.socket.on('disconnect', (reason: any) => {
       console.warn('disconnected', reason);
       this.isConnected = false;


### PR DESCRIPTION
Timer still resets on every page change, and is also active on the drawing page. I just added a check to avoid opening the idle timeout box while on the drawing page. Seemed like the simplest solution to me.